### PR TITLE
Replaced references

### DIFF
--- a/.ci/Layers/Default_GCC/README.md
+++ b/.ci/Layers/Default_GCC/README.md
@@ -7,7 +7,7 @@ Device: **STM32F429ZIT6**
 System Core Clock: **168 MHz**
 
 This setup is configured using **STM32CubeMX**, an interactive tool provided by STMicroelectronics for device configuration.
-Refer to ["Configure STM32 Devices with CubeMX"](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/CubeMX.md) for additional information.
+Refer to ["Configure STM32 Devices with CubeMX"](https://open-cmsis-pack.github.io/cmsis-toolbox/CubeMX/) for additional information.
 
 ### System Configuration
 
@@ -36,7 +36,7 @@ Refer to ["Configure STM32 Devices with CubeMX"](https://github.com/Open-CMSIS-P
 
 > Note: D11 (SPI_COPI) pin on Arduino Connector is unavailable, because it is used by the Ethernet configuration.
 
-Reference to [Arduino UNO connector description](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#arduino-shield).
+Reference to [Arduino UNO connector description](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#arduino-shield).
 
 ### CMSIS-Driver Virtual I/O mapping
 

--- a/Documents/OVERVIEW.md
+++ b/Documents/OVERVIEW.md
@@ -2,7 +2,7 @@
 
 The **STMicroelectronics NUCLEO-F429ZI Board Support Pack (BSP)**:
 
-- Contains examples and board layers in *csolution format* for usage with the [CMSIS-Toolbox](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/README.md) and the  [VS Code CMSIS Solution](https://marketplace.visualstudio.com/items?itemName=Arm.cmsis-csolution) extension.
+- Contains examples and board layers in *csolution format* for usage with the [CMSIS-Toolbox](https://open-cmsis-pack.github.io/cmsis-toolbox/) and the  [VS Code CMSIS Solution](https://marketplace.visualstudio.com/items?itemName=Arm.cmsis-csolution) extension.
 - Requires the [Device Family Pack (DFP) for the STM32F4 series](https://www.keil.arm.com/packs/stm32f4xx_dfp-keil).
 - Is configured with [STM32CubeMX](https://www.st.com/en/development-tools/stm32cubemx.html) for the Arm Compiler 6 (MDK). [Using GCC Compiler](#using-gcc-compiler) explains how to configured it for a different compiler.
 
@@ -10,7 +10,7 @@ The **STMicroelectronics NUCLEO-F429ZI Board Support Pack (BSP)**:
 
 - [Examples/Blinky](https://github.com/Open-CMSIS-Pack/ST_NUCLEO-F429ZI_BSP/tree/main/Examples/Blinky) shows the basic usage of this board.
 
-- [Board Layer](https://github.com/Open-CMSIS-Pack/ST_NUCLEO-F429ZI_BSP/tree/main/Layers/Default) for device-agnostic [Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md) that implements these API interfaces:
+- [Board Layer](https://github.com/Open-CMSIS-Pack/ST_NUCLEO-F429ZI_BSP/tree/main/Layers/Default) for device-agnostic [Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/) that implements these API interfaces:
 
 | Provided API Interface        | Description
 |:------------------------------|:------------------------------------------------------------------------------

--- a/Layers/Default/README.md
+++ b/Layers/Default/README.md
@@ -7,7 +7,7 @@ Device: **STM32F429ZIT6**
 System Core Clock: **168 MHz**
 
 This setup is configured using **STM32CubeMX**, an interactive tool provided by STMicroelectronics for device configuration.
-Refer to ["Configure STM32 Devices with CubeMX"](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/CubeMX.md) for additional information.
+Refer to ["Configure STM32 Devices with CubeMX"](https://open-cmsis-pack.github.io/cmsis-toolbox/CubeMX/) for additional information.
 
 ### System Configuration
 
@@ -36,7 +36,7 @@ Refer to ["Configure STM32 Devices with CubeMX"](https://github.com/Open-CMSIS-P
 
 > Note: D11 (SPI_COPI) pin on Arduino Connector is unavailable, because it is used by the Ethernet configuration.
 
-Reference to [Arduino UNO connector description](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md#arduino-shield).
+Reference to [Arduino UNO connector description](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/#arduino-shield).
 
 ### CMSIS-Driver Virtual I/O mapping
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This is the development repository for the **STMicroelectronics NUCLEO-F429ZI Board Support Pack (BSP)** - a CMSIS software pack that is designed to work with all compiler toolchains (Arm Compiler, GCC, IAR, LLVM). It is released as [CMSIS software pack](https://www.keil.arm.com/packs/nucleo-f429zi_bsp-keil) and therefore accessible by CMSIS-Pack enabled software development tools.
 
-This BSP uses the generator integration of the [CMSIS-Toolbox to Configure STM32 Devices with CubeMX](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/CubeMX.md) that is also supported in µVision 5.40 and higher.
+This BSP uses the generator integration of the [CMSIS-Toolbox to Configure STM32 Devices with CubeMX](https://open-cmsis-pack.github.io/cmsis-toolbox/CubeMX/) that is also supported in µVision 5.40 and higher.
 
 ## Repository top-level structure
 
@@ -19,11 +19,11 @@ Directory                   | Description
 [Documents](https://github.com/Open-CMSIS-Pack/ST_NUCLEO-F429ZI_BSP/tree/main/Documents)                 | [Usage overview](https://github.com/Open-CMSIS-Pack/ST_NUCLEO-F429ZI_BSP/tree/main/Documents/OVERVIEW.md) for examples and board documentation provided by STMicroelectronics.
 [Examples/Blinky](https://github.com/Open-CMSIS-Pack/ST_NUCLEO-F429ZI_BSP/tree/main/Examples/Blinky)     | Blinky example in *csolution project format* using [CMSIS-Driver VIO](https://arm-software.github.io/CMSIS_6/latest/Driver/group__vio__interface__gr.html) and [CMSIS-Compiler](https://arm-software.github.io/CMSIS-Compiler/main/index.html) for printf I/O retargeting.
 [Images](https://github.com/Open-CMSIS-Pack/ST_NUCLEO-F429ZI_BSP/tree/main/Images)                       | [Pictures](https://github.com/Open-CMSIS-Pack/ST_NUCLEO-F429ZI_BSP/blob/main/Images/nucleo-f429zi_large.png) of the board.
-[Layers](https://github.com/Open-CMSIS-Pack/ST_NUCLEO-F429ZI_BSP/tree/main/Layers)                       | Board layers for using the board with [CMSIS-Toolbox - Reference Applications](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/ReferenceApplications.md).
+[Layers](https://github.com/Open-CMSIS-Pack/ST_NUCLEO-F429ZI_BSP/tree/main/Layers)                       | Board layers for using the board with [CMSIS-Toolbox - Reference Applications](https://open-cmsis-pack.github.io/cmsis-toolbox/ReferenceApplications/).
 
 ## Using the development repository
 
-This development repository can be used in a local directory and [mapped as software pack](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/blob/main/docs/build-tools.md#install-a-repository) using for example `cpackget` with:
+This development repository can be used in a local directory and [mapped as software pack](https://open-cmsis-pack.github.io/cmsis-toolbox/build-tools#install-a-repository) using for example `cpackget` with:
 
     cpackget add <path>/Keil.NUCLEO-F429ZI_BSP.pdsc
 


### PR DESCRIPTION
Replaced references to https://github.com/Open-CMSIS-Pack/cmsis-toolbox/... to https://open-cmsis-pack.github.io/cmsis-toolbox/ a.o
[Issue 248](https://github.com/Open-CMSIS-Pack/cmsis-toolbox/issues/248)