### PR TITLE
Updated vcpkg-configuration.json to use at least cmsis-toolbox version 2.90. a.o.

### DIFF
--- a/.ci/vcpkg-configuration.json
+++ b/.ci/vcpkg-configuration.json
@@ -7,11 +7,11 @@
         }
     ],
     "requires": {
-        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.6.0",
-        "arm:tools/arm/mdk-toolbox":" ^1.0.0",
-        "arm:tools/kitware/cmake": "^3.28.4",
-        "arm:tools/ninja-build/ninja": "^1.12.0",
-        "arm:compilers/arm/armclang": "^6.22.0",
-        "arm:compilers/arm/arm-none-eabi-gcc": "^13.3.1"
+        "arm:tools/open-cmsis-pack/cmsis-toolbox": "^2.9.0",
+        "arm:tools/arm/mdk-toolbox":" ^1.1.0",
+        "arm:tools/kitware/cmake": "^3.31.5",
+        "arm:tools/ninja-build/ninja": "^1.12.1",
+        "arm:compilers/arm/armclang": "^6.24.0",
+        "arm:compilers/arm/arm-none-eabi-gcc": "^14.2.1"
     }
 }

--- a/.github/workflows/Test-Examples.yml
+++ b/.github/workflows/Test-Examples.yml
@@ -62,13 +62,13 @@ jobs:
         working-directory: ./
         run: |
           mkdir -p ./CI/Examples/Blinky
-          cp -rf ./BSP/Examples/Blinky/* ./CI/Examples/Blinky/
+          cp -a ./BSP/Examples/Blinky/. ./CI/Examples/Blinky/
 
       - name: Build Blinky AC6
         if: always()
         working-directory: ./CI/Examples/Blinky
         run: |
-          cbuild ./Blinky.csolution.yml --packs --update-rte --packs --toolchain AC6 --rebuild
+          cbuild ./Blinky.csolution.yml --packs --toolchain AC6 --rebuild
 
       - name: Upload Artifact of the Blinky AC6 build
         if: always()

--- a/.github/workflows/Test-MDK-Middleware-RefApps.yml
+++ b/.github/workflows/Test-MDK-Middleware-RefApps.yml
@@ -77,7 +77,7 @@ jobs:
         working-directory: ./
         run: |
           mkdir -p ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/Board/
-          cp -a ./MDK-Middleware/Examples/* ./CI/MW-RefApps/Examples/
+          cp -a ./MDK-Middleware/Examples/. ./CI/MW-RefApps/Examples/
 
       - name: Replace specific csolution files
         working-directory: ./

--- a/.github/workflows/Test-MDK-Middleware-RefApps.yml
+++ b/.github/workflows/Test-MDK-Middleware-RefApps.yml
@@ -19,10 +19,8 @@ jobs:
       fail-fast: false
       matrix:
         solution: [
-#         {name: FileSystem, dir: FileSystem, layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC},
           {name: Network,    dir: Network,    layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC},
-          {name: USB_Device, dir: USB/Device, layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC},
-#         {name: USB_Host,   dir: USB/Host,   layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC}
+          {name: USB_Device, dir: USB/Device, layer_ac6: ./BSP/Layers/Default, layer_gcc: ./.ci/Layers/Default_GCC}
         ]
 
     steps:
@@ -78,15 +76,20 @@ jobs:
       - name: Copy example structure to CI/MW-RefApps/ folder
         working-directory: ./
         run: |
-          mkdir -p ./CI/MW-RefApps/Examples/
           mkdir -p ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/Board/
-          cp -rf ./MDK-Middleware/Examples/* ./CI/MW-RefApps/Examples/
+          cp -a ./MDK-Middleware/Examples/* ./CI/MW-RefApps/Examples/
 
+      - name: Replace specific csolution files
+        working-directory: ./
+        run: |
           if [ -e ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ]
           then
-             cp -rf ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
+             cp -f ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
           fi
 
+      - name: Add the board layer to the ${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
+        working-directory: ./
+        run: |
           sed -i "s|target-types:|&\n    - type: $TARGET_BOARD\n      board: $TARGET_BOARD\n      variables:\n        - Board-Layer: \$SolutionDir()\$/Board/Board.clayer.yml|"  ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
 
       - name: Update board layer for ${{ matrix.solution.name }} AC6 build test

--- a/.github/workflows/Test-MDK-Middleware-RefApps.yml
+++ b/.github/workflows/Test-MDK-Middleware-RefApps.yml
@@ -87,6 +87,11 @@ jobs:
              cp -f ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
           fi
 
+      - name: Add the board layer to the ${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
+        working-directory: ./
+        run: |
+          sed -i "s|target-types:|&\n    - type: $TARGET_BOARD\n      board: $TARGET_BOARD\n      variables:\n        - Board-Layer: \$SolutionDir()\$/Board/Board.clayer.yml|"  ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
+
       - name: Update board layer for ${{ matrix.solution.name }} AC6 build test
         if: always()
         working-directory: ./

--- a/.github/workflows/Test-MDK-Middleware-RefApps.yml
+++ b/.github/workflows/Test-MDK-Middleware-RefApps.yml
@@ -87,29 +87,41 @@ jobs:
              cp -f ./.ci/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
           fi
 
-      - name: Add the board layer to the ${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
-        working-directory: ./
-        run: |
-          sed -i "s|target-types:|&\n    - type: $TARGET_BOARD\n      board: $TARGET_BOARD\n      variables:\n        - Board-Layer: \$SolutionDir()\$/Board/Board.clayer.yml|"  ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/${{ matrix.solution.name }}.csolution.yml
-
       - name: Update board layer for ${{ matrix.solution.name }} AC6 build test
         if: always()
         working-directory: ./
         run: |
           cp -rf ${{ matrix.solution.layer_ac6 }}/* ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/Board/   # Copy the Board layer
 
-      - name: ${{ matrix.solution.name }} AC6 build test
+      - name: ${{ matrix.solution.name }} AC6 build test (Release)
         if: always()
         working-directory: ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/
         run: |
-          cbuild ./${{ matrix.solution.name }}.csolution.yml --update-rte --packs \
-          --toolchain AC6 --rebuild
+          cbuild ./${{ matrix.solution.name }}.csolution.yml --context .Release+* \
+          --update-rte --packs --toolchain AC6 --rebuild
 
-      - name: Upload Artifact of the ${{ matrix.solution.name }} AC6 build
+      - name: Upload Artifact of the ${{ matrix.solution.name }} AC6 build (Release)
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.solution.name }}_AC6
+          name: ${{ matrix.solution.name }}_AC6_Release
+          path: |
+            ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/
+            !./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/tmp/
+          retention-days: 1
+
+      - name: ${{ matrix.solution.name }} AC6 build test (Debug)
+        if: always()
+        working-directory: ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/
+        run: |
+          cbuild ./${{ matrix.solution.name }}.csolution.yml --context .Debug+* \
+          --update-rte --packs --toolchain AC6 --rebuild
+
+      - name: Upload Artifact of the ${{ matrix.solution.name }} AC6 build (Debug)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.solution.name }}_AC6_Debug
           path: |
             ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/
             !./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/tmp/
@@ -122,20 +134,39 @@ jobs:
           rm -rf ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/Board/*
           cp -rf ${{ matrix.solution.layer_gcc }}/* ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/Board/   # Copy the Board layer
 
-      - name: ${{ matrix.solution.name }} GCC build test
+      - name: ${{ matrix.solution.name }} GCC build test (Release)
         if: always()
         working-directory: ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/
         run: |
           rm -rf out
           rm -rf tmp
-          cbuild ./${{ matrix.solution.name }}.csolution.yml --update-rte --packs \
-          --toolchain GCC --rebuild
+          cbuild ./${{ matrix.solution.name }}.csolution.yml --context .Release+* \
+          --update-rte --packs --toolchain GCC --rebuild
 
-      - name: Upload Artifact of the ${{ matrix.solution.name }} GCC build
+      - name: Upload Artifact of the ${{ matrix.solution.name }} GCC build (Release)
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.solution.name }}_GCC
+          name: ${{ matrix.solution.name }}_GCC_Release
+          path: |
+            ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/
+            !./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/tmp/
+          retention-days: 1
+
+      - name: ${{ matrix.solution.name }} GCC build test (Debug)
+        if: always()
+        working-directory: ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/
+        run: |
+          rm -rf out
+          rm -rf tmp
+          cbuild ./${{ matrix.solution.name }}.csolution.yml --context .Debug+* \
+          --update-rte --packs --toolchain GCC --rebuild
+
+      - name: Upload Artifact of the ${{ matrix.solution.name }} GCC build (Debug)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.solution.name }}_GCC_Debug
           path: |
             ./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/
             !./CI/MW-RefApps/Examples/${{ matrix.solution.dir }}/tmp/

--- a/Examples/Blinky/.cmsis/Blinky+NUCLEO-F429ZI.dbgconf
+++ b/Examples/Blinky/.cmsis/Blinky+NUCLEO-F429ZI.dbgconf
@@ -1,0 +1,48 @@
+// File: STM32F405_415_407_417_427_437_429_439.dbgconf
+// Version: 1.0.0
+// Note: refer to STM32F405/415 STM32F407/417 STM32F427/437 STM32F429/439 reference manual (RM0090)
+//       refer to STM32F40x STM32F41x datasheets
+//       refer to STM32F42x STM32F43x datasheets
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//   <o.2>  DBG_STANDBY              <i> Debug Standby Mode
+//   <o.1>  DBG_STOP                 <i> Debug Stop Mode
+//   <o.0>  DBG_SLEEP                <i> Debug Sleep Mode
+// </h>
+DbgMCU_CR = 0x00000007;
+
+// <h> Debug MCU APB1 freeze register (DBGMCU_APB1_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.26> DBG_CAN2_STOP            <i> CAN2 stopped when core is halted
+//   <o.25> DBG_CAN1_STOP            <i> CAN2 stopped when core is halted
+//   <o.23> DBG_I2C3_SMBUS_TIMEOUT   <i> I2C3 SMBUS timeout mode stopped when core is halted
+//   <o.22> DBG_I2C2_SMBUS_TIMEOUT   <i> I2C2 SMBUS timeout mode stopped when core is halted
+//   <o.21> DBG_I2C1_SMBUS_TIMEOUT   <i> I2C1 SMBUS timeout mode stopped when core is halted
+//   <o.12> DBG_IWDG_STOP            <i> Independent watchdog stopped when core is halted
+//   <o.11> DBG_WWDG_STOP            <i> Window watchdog stopped when core is halted
+//   <o.10> DBG_RTC_STOP             <i> RTC stopped when core is halted
+//   <o.8>  DBG_TIM14_STOP           <i> TIM14 counter stopped when core is halted
+//   <o.7>  DBG_TIM13_STOP           <i> TIM13 counter stopped when core is halted
+//   <o.6>  DBG_TIM12_STOP           <i> TIM12 counter stopped when core is halted
+//   <o.5>  DBG_TIM7_STOP            <i> TIM7 counter stopped when core is halted
+//   <o.4>  DBG_TIM6_STOP            <i> TIM6 counter stopped when core is halted
+//   <o.3>  DBG_TIM5_STOP            <i> TIM5 counter stopped when core is halted
+//   <o.2>  DBG_TIM4_STOP            <i> TIM4 counter stopped when core is halted
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 counter stopped when core is halted
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 counter stopped when core is halted
+// </h>
+DbgMCU_APB1_Fz = 0x00000000;
+
+// <h> Debug MCU APB2 freeze register (DBGMCU_APB2_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_TIM11_STOP           <i> TIM11 counter stopped when core is halted
+//   <o.17> DBG_TIM10_STOP           <i> TIM10 counter stopped when core is halted
+//   <o.16> DBG_TIM9_STOP            <i> TIM9 counter stopped when core is halted
+//   <o.1>  DBG_TIM8_STOP            <i> TIM8 counter stopped when core is halted
+//   <o.0>  DBG_TIM1_STOP            <i> TIM1 counter stopped when core is halted
+// </h>
+DbgMCU_APB2_Fz = 0x00000000;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/.cmsis/Blinky+NUCLEO-F429ZI.dbgconf.base@0.0.0
+++ b/Examples/Blinky/.cmsis/Blinky+NUCLEO-F429ZI.dbgconf.base@0.0.0
@@ -1,0 +1,48 @@
+// File: STM32F405_415_407_417_427_437_429_439.dbgconf
+// Version: 1.0.0
+// Note: refer to STM32F405/415 STM32F407/417 STM32F427/437 STM32F429/439 reference manual (RM0090)
+//       refer to STM32F40x STM32F41x datasheets
+//       refer to STM32F42x STM32F43x datasheets
+
+// <<< Use Configuration Wizard in Context Menu >>>
+
+// <h> Debug MCU configuration register (DBGMCU_CR)
+//   <o.2>  DBG_STANDBY              <i> Debug Standby Mode
+//   <o.1>  DBG_STOP                 <i> Debug Stop Mode
+//   <o.0>  DBG_SLEEP                <i> Debug Sleep Mode
+// </h>
+DbgMCU_CR = 0x00000007;
+
+// <h> Debug MCU APB1 freeze register (DBGMCU_APB1_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.26> DBG_CAN2_STOP            <i> CAN2 stopped when core is halted
+//   <o.25> DBG_CAN1_STOP            <i> CAN2 stopped when core is halted
+//   <o.23> DBG_I2C3_SMBUS_TIMEOUT   <i> I2C3 SMBUS timeout mode stopped when core is halted
+//   <o.22> DBG_I2C2_SMBUS_TIMEOUT   <i> I2C2 SMBUS timeout mode stopped when core is halted
+//   <o.21> DBG_I2C1_SMBUS_TIMEOUT   <i> I2C1 SMBUS timeout mode stopped when core is halted
+//   <o.12> DBG_IWDG_STOP            <i> Independent watchdog stopped when core is halted
+//   <o.11> DBG_WWDG_STOP            <i> Window watchdog stopped when core is halted
+//   <o.10> DBG_RTC_STOP             <i> RTC stopped when core is halted
+//   <o.8>  DBG_TIM14_STOP           <i> TIM14 counter stopped when core is halted
+//   <o.7>  DBG_TIM13_STOP           <i> TIM13 counter stopped when core is halted
+//   <o.6>  DBG_TIM12_STOP           <i> TIM12 counter stopped when core is halted
+//   <o.5>  DBG_TIM7_STOP            <i> TIM7 counter stopped when core is halted
+//   <o.4>  DBG_TIM6_STOP            <i> TIM6 counter stopped when core is halted
+//   <o.3>  DBG_TIM5_STOP            <i> TIM5 counter stopped when core is halted
+//   <o.2>  DBG_TIM4_STOP            <i> TIM4 counter stopped when core is halted
+//   <o.1>  DBG_TIM3_STOP            <i> TIM3 counter stopped when core is halted
+//   <o.0>  DBG_TIM2_STOP            <i> TIM2 counter stopped when core is halted
+// </h>
+DbgMCU_APB1_Fz = 0x00000000;
+
+// <h> Debug MCU APB2 freeze register (DBGMCU_APB2_FZ)
+//                                   <i> Reserved bits must be kept at reset value
+//   <o.18> DBG_TIM11_STOP           <i> TIM11 counter stopped when core is halted
+//   <o.17> DBG_TIM10_STOP           <i> TIM10 counter stopped when core is halted
+//   <o.16> DBG_TIM9_STOP            <i> TIM9 counter stopped when core is halted
+//   <o.1>  DBG_TIM8_STOP            <i> TIM8 counter stopped when core is halted
+//   <o.0>  DBG_TIM1_STOP            <i> TIM1 counter stopped when core is halted
+// </h>
+DbgMCU_APB2_Fz = 0x00000000;
+
+// <<< end of configuration section >>>

--- a/Examples/Blinky/Blinky.csolution.yml
+++ b/Examples/Blinky/Blinky.csolution.yml
@@ -1,6 +1,6 @@
 # A solution is a collection of related projects that share same base configuration.
 solution:
-  created-for: CMSIS-Toolbox@2.6.0
+  created-for: CMSIS-Toolbox@2.9.0
   cdefault:
 
   # List of tested compilers that can be selected

--- a/Keil.NUCLEO-F429ZI_BSP.pdsc
+++ b/Keil.NUCLEO-F429ZI_BSP.pdsc
@@ -21,6 +21,9 @@
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
       - add RTE_Components.h files
+      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
+      - add dbgconf files for the Blinky example.
+      - updated RTE_Components.h file.	  
     </release>
   </releases>
 

--- a/Keil.NUCLEO-F429ZI_BSP.pdsc
+++ b/Keil.NUCLEO-F429ZI_BSP.pdsc
@@ -21,7 +21,6 @@
       - modify app_main_thread (replace loop forever)
       - add DWARF-5 debug information
       - add RTE_Components.h files
-      - updated settings in vcpkg-configuration.json file to use cmsis-toolbox 2.9.0
       - add dbgconf files for the Blinky example.
       - updated RTE_Components.h file.	  
     </release>

--- a/Keil.NUCLEO-F429ZI_BSP.pdsc
+++ b/Keil.NUCLEO-F429ZI_BSP.pdsc
@@ -22,7 +22,8 @@
       - add DWARF-5 debug information
       - add RTE_Components.h files
       - add dbgconf files for the Blinky example.
-      - updated RTE_Components.h file.	  
+      - updated RTE_Components.h file.
+      - updated vcpkg-configuration.json to use at least cmsis-toolbox version 2.90.
     </release>
   </releases>
 

--- a/Keil.NUCLEO-F429ZI_BSP.pdsc
+++ b/Keil.NUCLEO-F429ZI_BSP.pdsc
@@ -23,7 +23,6 @@
       - add RTE_Components.h files
       - add dbgconf files for the Blinky example.
       - updated RTE_Components.h file.
-      - updated vcpkg-configuration.json to use at least cmsis-toolbox version 2.90.
     </release>
   </releases>
 


### PR DESCRIPTION
- Updated vcpkg-configuration.json to use at least cmsis-toolbox version 2.90.
- Split the action for preparing the MW-RefApps folder structure into 3 smaller actions to improve readability.
- Split the monolithic build test actions for AC6 and GCC in to a Release and a Debug action.
- Added dbgconf files for the Blinky example.
- Updated pack version number and release notes in pdsc file.
- 